### PR TITLE
Fix: 자소서 첨삭 PDF에서 체크마크와 번호 중복 표시 문제 수정

### DIFF
--- a/frontend/src/services/pdfGenerationService.ts
+++ b/frontend/src/services/pdfGenerationService.ts
@@ -471,7 +471,9 @@ export async function generateFeedbackPDF(
         currentY = PAGE_MARGIN.top;
       }
       currentY += 4;
-      currentY = addKoreanText(doc, `✓ ${suggestion}`, PAGE_MARGIN.left + 10, currentY, {
+      // 기존 체크마크 제거
+      const cleanSuggestion = suggestion.replace(/^[✓✔☑]+\s*/, '').trim();
+      currentY = addKoreanText(doc, `✓ ${cleanSuggestion}`, PAGE_MARGIN.left + 10, currentY, {
         fontSize: 12,
         maxWidth: CONTENT_WIDTH - 15,
         color: COLORS.text,
@@ -570,7 +572,9 @@ export async function generateFeedbackPDF(
         currentY = PAGE_MARGIN.top;
       }
       currentY += 4;
-      currentY = addKoreanText(doc, `✓ ${strength}`, PAGE_MARGIN.left + 10, currentY, {
+      // 기존 체크마크 제거 (LLM 응답에 이미 포함되어 있을 수 있음)
+      const cleanStrength = strength.replace(/^[✓✔☑]+\s*/, '').trim();
+      currentY = addKoreanText(doc, `✓ ${cleanStrength}`, PAGE_MARGIN.left + 10, currentY, {
         fontSize: 12,
         maxWidth: CONTENT_WIDTH - 15,
         color: COLORS.success,
@@ -594,7 +598,9 @@ export async function generateFeedbackPDF(
         currentY = PAGE_MARGIN.top;
       }
       currentY += 4;
-      currentY = addKoreanText(doc, `✗ ${weakness}`, PAGE_MARGIN.left + 10, currentY, {
+      // 기존 X 마크 제거 (LLM 응답에 이미 포함되어 있을 수 있음)
+      const cleanWeakness = weakness.replace(/^[✗✘×]+\s*/, '').trim();
+      currentY = addKoreanText(doc, `✗ ${cleanWeakness}`, PAGE_MARGIN.left + 10, currentY, {
         fontSize: 12,
         maxWidth: CONTENT_WIDTH - 15,
         color: COLORS.error,
@@ -819,7 +825,9 @@ export async function generateFeedbackPDF(
         currentY = PAGE_MARGIN.top;
       }
       currentY += 4;
-      currentY = addKoreanText(doc, `${i + 1}. ${improvement}`, PAGE_MARGIN.left + 5, currentY, {
+      // 기존 번호 제거 (LLM 응답에 이미 포함되어 있을 수 있음)
+      const cleanImprovement = improvement.replace(/^\d+\.\s*/, '').trim();
+      currentY = addKoreanText(doc, `${i + 1}. ${cleanImprovement}`, PAGE_MARGIN.left + 5, currentY, {
         fontSize: 12,
         maxWidth: CONTENT_WIDTH - 10,
         color: COLORS.text,


### PR DESCRIPTION
- 문제: LLM 응답에 이미 포함된 기호/번호가 PDF 생성 시 다시 추가되어 "✓ ✓ 강점", "× × 약점", "1. 1. 개선사항" 형태로 중복 표시됨

- 해결:
  1. 체크마크 중복 제거 - strengths: ✓, ✔, ☑ 기호 제거 후 재추가 - weaknesses: ✗, ✘, × 기호 제거 후 재추가 - suggestions: ✓, ✔, ☑ 기호 제거 후 재추가

  2. 번호 중복 제거
     - keyImprovements: "1.", "2." 등 기존 번호 제거 후 재추가

- 수정 파일: pdfGenerationService.ts
  - Line 474-475: suggestions 체크마크 중복 제거
  - Line 573-575: strengths 체크마크 중복 제거
  - Line 599-601: weaknesses X 마크 중복 제거
  - Line 828-830: keyImprovements 번호 중복 제거

이제 PDF 첨삭 문서에서 기호와 번호가 한 번만 표시됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)